### PR TITLE
filter out WESTbahn and PKP Intercity services in local-only mode

### DIFF
--- a/src/reachableFrom.js
+++ b/src/reachableFrom.js
@@ -64,12 +64,17 @@ const reachableForDay = async (date, stationId, localTrainsOnly) => {
 	const reachable = l.flatMap(trainDepartures, departure => {
 		// todo: make this less brittle
 		if (localTrainsOnly) {
+			// EuroNight (EN) services are sometimes misclassified as regional trains
+			// so we filter them out manually.
+			if (departure.line.name.startsWith('EN')) return []
 			// since some privately operated trains are wrongly categorized as
 			// regional transit, we filter them out manually. this list is
 			// probably incomplete.
+			if (departure.line.operator?.name === 'European Sleeper') return []
 			if (departure.line.operator?.name === 'FlixTrain') return []
 			if (departure.line.operator?.name === 'Snälltåget') return []
 			if (departure.line.operator?.name === 'Urlaubs-Express') return []
+			if (departure.line.operator?.name === 'WESTbahn') return []
 		}
 
 		const { when, nextStopovers = [] } = departure


### PR DESCRIPTION
The difference can be seen for Munich central station, where the Westbahn services to Vienna and the EuroNight serivces to Warsaw are no longer shown.